### PR TITLE
Fixed crash occurring when processing words ending with 'ssion'.

### DIFF
--- a/ldt/dicts/derivation/custom/en/en.py
+++ b/ldt/dicts/derivation/custom/en/en.py
@@ -96,7 +96,8 @@ class EnglishDerivation(DerivationCustomDict):
 
         if word.endswith("ssion"):
             if self.dictionary.is_a_word(word[:-3]):
-                return word[:-3]
+                res["suffixes"].append("-ion")
+                res["roots"].append(word[:-3])
             else:
                 endings = ["d", "t", "de", "se"]
                 for end in endings:

--- a/ldt/dicts/normalize.py
+++ b/ldt/dicts/normalize.py
@@ -114,7 +114,9 @@ def turn_to_words(word):
             if subword:
                 res.append(subword)
             subword = ""
-    res.append(subword)
+
+    if subword:
+        res.append(subword)
     return res
 
 class Normalization(MorphMetaDict):

--- a/ldt/dicts/semantics/wiktionary.py
+++ b/ldt/dicts/semantics/wiktionary.py
@@ -141,6 +141,8 @@ class Wiktionary(BaseWiktionary, LexicographicDictionary):
             new_res = {k: v for k, v in dicts.items() if k in relations}
 
             return new_res
+        else:
+            return {}
 
 
 # def dig_deeper(input, field, res):

--- a/ldt/dicts/spellcheck/en/en.py
+++ b/ldt/dicts/spellcheck/en/en.py
@@ -299,7 +299,7 @@ class SpellcheckerEn(Spellchecker):
             if word[ind].lower() in inserts and len(inserts) == 1:
                 if word[ind].lower() == word[ind-1].lower():
                     res.append("double_letter_missed")
-                elif len(word) >= ind+1:
+                elif len(word) > ind+1:
                     if word[ind].lower() == word[ind+1].lower():
                         res.append("double_letter_missed")
         return res

--- a/ldt/relations/ontology_path/en.py
+++ b/ldt/relations/ontology_path/en.py
@@ -66,5 +66,5 @@ def get_shortest_path(word1, word2):
     """
     try:
         return _get_wn_paths(word1, word2)
-    except timeout_decorator.timeout_decorator.TimeoutError:
+    except AssertionError:
         return 0


### PR DESCRIPTION
There is a bug that leads to a crash when processing the word 'discussion'.
This is due to the _suffix_sion function not returning a dictionary in all cases.

I changed it to what I think it should look like.